### PR TITLE
Fix auto-download and url-encoded filenames on FA

### DIFF
--- a/app/plugins/furaffinity.ts
+++ b/app/plugins/furaffinity.ts
@@ -43,7 +43,7 @@ export class FuraffinityPlugin extends BaseSitePlugin {
         // thumbnail size.
 
         let urlParts = url.split("/");
-        let serviceFilename = urlParts[urlParts.length - 1];
+        let serviceFilename = decodeURIComponent(urlParts[urlParts.length - 1]);
         let { filename, ext } = getFilenameParts(serviceFilename);
 
         // Use the submission's ID number instead of any id numbers in the download URL, 

--- a/app/ui/page/settingsUi.tsx
+++ b/app/ui/page/settingsUi.tsx
@@ -29,7 +29,7 @@ export default class SettingsUi extends React.Component<SettingsUiProps, Setting
         }
     }
 
-    componentWillReceiveProps(nextProps: SettingsUiProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: SettingsUiProps) {
         // Only update the default settings in response to settings changes
         // (since we're in the editor for site settings changes)
         const defaultSettings = Object.assign({}, nextProps.settings.defaultSettings);

--- a/app/ui/siteSettingsUi.tsx
+++ b/app/ui/siteSettingsUi.tsx
@@ -361,7 +361,7 @@ class TabDelay extends React.Component<TabDelayProps, TabDelayState> {
         }
     }
 
-    componentWillReceiveProps(nextProps: TabDelayProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: TabDelayProps) {
         if (parseInt(this.state.value, 10) !== nextProps.value) {
             this.setState({ value: `${nextProps.value}` });
         }

--- a/app/utils/sleep.ts
+++ b/app/utils/sleep.ts
@@ -1,0 +1,5 @@
+export async function sleep(timeInMs: number) {
+    return new Promise((resolve) => {
+        const timer = setTimeout(resolve, timeInMs)
+    });
+}


### PR DESCRIPTION
Fixes for #35 and #45 
#35 was caused by a race condition between when we retrieved settings and when we checked for them, and #45 was caused by FA url-encoding the filename, which was fixed by doing a url-decode before using it.