### PR TITLE
Add date & time placeholders for download filename format string

### DIFF
--- a/app/download.ts
+++ b/app/download.ts
@@ -2,6 +2,7 @@ import * as I from './definitions';
 import * as logger from './logger';
 import IntlMessageFormat from 'intl-messageformat';
 import { DownloadDestination } from './enums';
+import { DateTime } from 'luxon';
 
 const downloadRootFolder = 'raccoony';
 const isFirefox = window.location.protocol === 'moz-extension:';
@@ -141,6 +142,10 @@ function replacePathPlaceholders(path: string, media: I.Media) {
         ? media.siteFilename
         : `${media.siteFilename}.${media.extension}`
 
+    const currentDate = new Date();
+    const isoDate = DateTime.fromJSDate(currentDate).toFormat("yyyy-MM-dd");
+    const isoTime = DateTime.fromJSDate(currentDate).toFormat("HH_mm_ss");
+        
     const vars = {
         siteName: media.siteName,
         submissionId: media.submissionId,
@@ -153,6 +158,9 @@ function replacePathPlaceholders(path: string, media: I.Media) {
         type: media.type,
         title: media.title,
         domain: url.hostname,
+        currentDate: currentDate,
+        isoDate,
+        isoTime
     };
 
     Object.getOwnPropertyNames(vars).forEach(k => {

--- a/app/download.ts
+++ b/app/download.ts
@@ -143,8 +143,9 @@ function replacePathPlaceholders(path: string, media: I.Media) {
         : `${media.siteFilename}.${media.extension}`
 
     const currentDate = new Date();
+    const currentTimestamp = `${currentDate.getTime()}`;
     const isoDate = DateTime.fromJSDate(currentDate).toFormat("yyyy-MM-dd");
-    const isoTime = DateTime.fromJSDate(currentDate).toFormat("HH_mm_ss");
+    const isoTime = DateTime.fromJSDate(currentDate).toFormat("HHmmss");
         
     const vars = {
         siteName: media.siteName,
@@ -158,7 +159,8 @@ function replacePathPlaceholders(path: string, media: I.Media) {
         type: media.type,
         title: media.title,
         domain: url.hostname,
-        currentDate: currentDate,
+        currentDate,
+        currentTimestamp,
         isoDate,
         isoTime
     };

--- a/app/settings.ts
+++ b/app/settings.ts
@@ -14,7 +14,7 @@ export const DefaultSiteSettings: I.SiteSettings = {
     tabLoadType: TabLoadType.Placeholder,
     writeMetadata: false,
     autoDownload: false,
-    contextDownloadPath: "raccoony/{siteName}/{author}/{filenameExt}",
+    contextDownloadPath: "raccoony/{siteName}/{author}/{isoDate}t{isoTime}{filenameExt}",
 };
 
 export const DefaultExtensionSettings: I.ExtensionSettings = {

--- a/app/settings.ts
+++ b/app/settings.ts
@@ -14,7 +14,7 @@ export const DefaultSiteSettings: I.SiteSettings = {
     tabLoadType: TabLoadType.Placeholder,
     writeMetadata: false,
     autoDownload: false,
-    contextDownloadPath: "raccoony/{siteName}/{author}/{isoDate}t{isoTime}{filenameExt}",
+    contextDownloadPath: "raccoony/{siteName}/{author}/{isoDate}t{isoTime}_{filenameExt}",
 };
 
 export const DefaultExtensionSettings: I.ExtensionSettings = {

--- a/app/ui/siteSettingsUi.tsx
+++ b/app/ui/siteSettingsUi.tsx
@@ -225,8 +225,9 @@ const placeholderList: [string, string][] = [
     ["title", "the title of the submission, if available"],
     ["domain", "the domain name, e.g. 'example.com'"],
     ["isoDate", "the current date in YYYY-MM-DD format"],
-    ["isoTime", "the current time in HH_MM_SS format"],
-    ["currentDate", "the current date as a JS object, formattable using the MessageFormat date and time types"]
+    ["isoTime", "the current time in HHMMSS format"],
+    ["currentDate", "the current date as a JS object, formattable using the MessageFormat date and time types"],
+    ["currentTimestamp", "the current date-time as a UNIX timestamp"]
 ];
 
 class DownloadPath extends React.Component<DownloadPathProps, DownloadPathState> {

--- a/app/ui/siteSettingsUi.tsx
+++ b/app/ui/siteSettingsUi.tsx
@@ -223,7 +223,10 @@ const placeholderList: [string, string][] = [
     ["extension", "the file extension (e.g. jpg, png)"],
     ["type", "the type of file; can be one of 'image', 'text', 'flash', 'video', 'audio' or 'unknown'"],
     ["title", "the title of the submission, if available"],
-    ["domain", "the domain name, e.g. 'example.com'"]
+    ["domain", "the domain name, e.g. 'example.com'"],
+    ["isoDate", "the current date in YYYY-MM-DD format"],
+    ["isoTime", "the current time in HH_MM_SS format"],
+    ["currentDate", "the current date as a JS object, formattable using the MessageFormat date and time types"]
 ];
 
 class DownloadPath extends React.Component<DownloadPathProps, DownloadPathState> {
@@ -254,7 +257,7 @@ class DownloadPath extends React.Component<DownloadPathProps, DownloadPathState>
                         <ul>
                             {placeholderList.map(([placeholder, description]) => (<li key={placeholder}><b>{`{${placeholder}}`}</b>{" - " + description}</li>))}
                         </ul>
-                        Format string can use any valid <a href="https://messageformat.github.io/guide/" target="_blank">ICU MessageFormat</a> syntax.
+                        Format string can use any valid <a href="https://formatjs.io/guides/message-syntax/" target="_blank">ICU MessageFormat</a> syntax.
                     </div>
                 )}
             </React.Fragment>

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,11 @@
       "integrity": "sha512-/nofAE5XZ3MnJXy1AaS+/BxjNL3zjHciDBZHhE7f8wIOAgS9FM1JduGXAM3xn08rXumOPIIFRAr41aXf7dLN7w==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.22.0.tgz",
+      "integrity": "sha512-riAvdx85rU7OXCrjW3f7dIf7fuJDrxck2Dkjd0weh6ul7q+wumrwe6+/tD8v7yOKnZAuEnTFF4FU7b+5W/I3bw=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1480,7 +1485,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -8447,6 +8453,11 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "luxon": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.22.2.tgz",
+      "integrity": "sha512-vq6eSaOOw1fKob+JXwfu0e3/UFUT4G4HTFRJab7dch8J1OdOGW/vXqCiJsY7rm2In+5gKNYx0EtnYT0Tc5V4Qw=="
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -11515,7 +11526,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "@types/luxon": "^1.22.0",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "intl-messageformat": "^2.2.0",
+    "luxon": "^1.22.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-image-lightbox": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@types/luxon": "^1.22.0",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "intl-messageformat": "^2.2.0",
@@ -27,6 +26,7 @@
     "@types/chrome": "0.0.54",
     "@types/classnames": "^2.2.9",
     "@types/intl-messageformat": "^1.3.1",
+    "@types/luxon": "^1.22.0",
     "@types/react": "^16.9.20",
     "@types/react-dom": "^16.9.5",
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
I found out that Patreon's gallery ends up reporting a filename of "1.[ext]" for all files, with the uniqueness inside the path name. While I could write a specific parser for Patreon to make the right-click download more robust (and I probably will), this is a quick solution that will make right-click downloads more reliable overall by allowing the user to include a timestamp in the filename.