### PR TITLE
Only open tabs in the same window as the tab that kicked it off

### DIFF
--- a/app/background.ts
+++ b/app/background.ts
@@ -17,7 +17,11 @@ browser.runtime.onMessage.addListener((request: I.MessageRequest<any>, sender: c
             switch (request.action) {
                 case MessageAction.OpenTabs:
                     const list: I.PageLinkList = request.data;
-                    return openInTabs(list, settingsProvider.getCurrentSettings(list.siteName));
+                    return openInTabs(
+                        list, 
+                        settingsProvider.getCurrentSettings(list.siteName),
+                        { windowId: sender.tab.windowId }
+                    );
                 case MessageAction.Download:
                     const media: I.Media = request.data;
                     return download.downloadFile(media, settingsProvider.getCurrentSettings(media.siteName));

--- a/app/openTabs.ts
+++ b/app/openTabs.ts
@@ -7,18 +7,18 @@ type OpenInTabsOptions = {
     windowId: number,
 }
 
-export default function openInTabs(pageList: I.PageLinkList, settings: I.SiteSettings, options: OpenInTabsOptions) {
+export default function openInTabs(pageList: I.PageLinkList, siteSettings: I.SiteSettings, options: OpenInTabsOptions) {
     let list = pageList.list;
-    if (pageList.sortable && settings.tabLoadSortBy === E.TabLoadOrder.Date) {
+    if (pageList.sortable && siteSettings.tabLoadSortBy === E.TabLoadOrder.Date) {
         list.sort((a, b) => parseInt(a.submissionId) - parseInt(b.submissionId));
     }
-    if (!settings.tabLoadSortAsc) {
+    if (!siteSettings.tabLoadSortAsc) {
         list.reverse();
     }
 
-    const delaySecs = settings.tabLoadDelay || defaultDelaySecs;
+    const delaySecs = siteSettings.tabLoadDelay || defaultDelaySecs;
     list.forEach((page, idx) => {
-        if (settings.tabLoadType === E.TabLoadType.Timer) {
+        if (siteSettings.tabLoadType === E.TabLoadType.Timer) {
             openMediaInTabAfterDelay(page, (idx * delaySecs), options);
         }
         else {
@@ -39,8 +39,7 @@ function openMediaInPlaceholderTab(media: I.PageLink, delay: number) {
 }
 
 function openMediaInTabAfterDelay(media: I.PageLink, delay: number, options: OpenInTabsOptions) {
-    // Opens the page in the current active window after the specified delay.
-    // TODO: Do we need to check if the window that started the process is still there before specifying windowId?
+    // Opens the page in the specified window after the specified delay.
     setTimeout(() => {
         browser.tabs.create({
             url: media.url,

--- a/app/openTabs.ts
+++ b/app/openTabs.ts
@@ -3,7 +3,11 @@ import * as E from './enums';
 
 const defaultDelaySecs = 1;
 
-export default function openInTabs(pageList: I.PageLinkList, settings: I.SiteSettings) {
+type OpenInTabsOptions = {
+    windowId: number,
+}
+
+export default function openInTabs(pageList: I.PageLinkList, settings: I.SiteSettings, options: OpenInTabsOptions) {
     let list = pageList.list;
     if (pageList.sortable && settings.tabLoadSortBy === E.TabLoadOrder.Date) {
         list.sort((a, b) => parseInt(a.submissionId) - parseInt(b.submissionId));
@@ -15,7 +19,7 @@ export default function openInTabs(pageList: I.PageLinkList, settings: I.SiteSet
     const delaySecs = settings.tabLoadDelay || defaultDelaySecs;
     list.forEach((page, idx) => {
         if (settings.tabLoadType === E.TabLoadType.Timer) {
-            openMediaInTabAfterDelay(page, (idx * delaySecs));
+            openMediaInTabAfterDelay(page, (idx * delaySecs), options);
         }
         else {
             openMediaInPlaceholderTab(page, (idx * delaySecs));
@@ -34,13 +38,14 @@ function openMediaInPlaceholderTab(media: I.PageLink, delay: number) {
     })
 }
 
-function openMediaInTabAfterDelay(media: I.PageLink, delay: number) {
+function openMediaInTabAfterDelay(media: I.PageLink, delay: number, options: OpenInTabsOptions) {
     // Opens the page in the current active window after the specified delay.
-    // TODO: Need to check whether the requesting has been closed, or have a page or UI that can pause/stop the process
+    // TODO: Do we need to check if the window that started the process is still there before specifying windowId?
     setTimeout(() => {
         browser.tabs.create({
             url: media.url,
             active: false,
+            windowId: options.windowId,
         })
     }, delay * 1000);
 }


### PR DESCRIPTION
This makes it so that you can do an Open in Tabs in one window, then browse in another window, and the new tabs won't follow the active window but will instead stay in the opening window.

Known issue: if the original window is closed, it appears to stop the tabs from being opened. This may be the desired behavior given that there's no UI for aborting an open all in tabs action aside from quitting the browser otherwise.