### PR TITLE
Simon/itaku substar fixes

### DIFF
--- a/app/plugins/itaku.ts
+++ b/app/plugins/itaku.ts
@@ -132,7 +132,7 @@ export class ItakuPlugin extends BaseSitePlugin {
             pathname === '/home/images' ||
             pathname.startsWith('/posts') ||
             (pathname.startsWith('/profile') && (
-                pathname.endsWith('/gallery')
+                pathname.includes('/gallery')
             ));
 
     }

--- a/app/plugins/patreon.ts
+++ b/app/plugins/patreon.ts
@@ -33,9 +33,10 @@ export class PatreonPlugin extends BaseSitePlugin {
             // Get the post image
             let mediaElt: HTMLImageElement | HTMLAudioElement = 
                 // New 2023 Patreon layout
-                querySelector('[data-tag=post-card] img')
-                || querySelector('audio[tag=audio-player]')
+                // Look for audio players before looking for images
+                querySelector('audio[tag=audio-player]')
                 || querySelector("[data-tag=post-card] audio")
+                || querySelector('[data-tag=post-card] img')
                 // Old Patreon layout
                 || querySelector(".patreon-creation-shim--image");
 

--- a/app/plugins/sofurry.ts
+++ b/app/plugins/sofurry.ts
@@ -12,36 +12,46 @@ export class SofurryPlugin extends BaseSitePlugin {
     getMedia(): Promise<I.Media> {
         // TODO: support downloading stories
         // Get the download button
-        let button = document.getElementById("sfDownload") || querySelector("#sfContentImage a");
+        const button = document.getElementById("sfDownload") || querySelector("#sfContentImage a");
         if (!button) {
             return Promise.resolve(null);
         }
 
         // Get the URL
-        var url = button.getAttribute("href");
-        var id = window.location.href.split("/").pop();
+        const url = button.getAttribute("href");
+        const id = window.location.href.split("/").pop();
 
         // Get the filename
-        var titleElt = document.getElementById("sfContentTitle");
-        var filename = titleElt.textContent.trim();
-        // And the extension - we use the preview image to determine this.
-        var imgPreview: HTMLImageElement = querySelector("#sfContentImage img");
-        let previewUrl = imgPreview.src;
-        let previewUrlObj = new URL(previewUrl);
+        const titleElt = document.getElementById("sfContentTitle");
+        const filename = titleElt.textContent.trim();
+        // And the extension - we use the preview image or video to determine this.
+        const imgPreview = querySelector<HTMLImageElement | HTMLVideoElement>("#sfContentImage img, #sfContentImage video");
+        const previewUrl = imgPreview.currentSrc; // currentSrc works on both IMG and VIDEO tags
+        const previewUrlObj = new URL(previewUrl);
         let siteFilename = previewUrlObj.searchParams.get('filename');
-        var ext = siteFilename.split('.').pop();
+        let ext = '';
+        if (siteFilename) {
+            // Found a filename on the preview image URL
+            ext = siteFilename.split('.').pop();
+        }
+        else {
+            // Probably dealing with a video, need to synthesize a filename and extension
+            ext = previewUrlObj.searchParams.get('ext');
+            ext = ext.replace('.', '');
+            siteFilename = `${id}.${ext}`;
+        }
 
         // Get the username
-        var usernameElt = document.querySelector("#sf-userinfo-outer .sf-username");
-        var username = usernameElt.textContent;
+        const usernameElt = document.querySelector("#sf-userinfo-outer .sf-username");
+        const username = usernameElt.textContent;
 
-        let title = filename;
-        let descriptionElt = querySelector("#sfContentDescription");
-        let description = descriptionElt && descriptionElt.textContent.trim();
-        let tags = querySelectorAll("#submission_tags .sf-tag")
+        const title = filename;
+        const descriptionElt = querySelector("#sfContentDescription");
+        const description = descriptionElt && descriptionElt.textContent.trim();
+        const tags = querySelectorAll("#submission_tags .sf-tag")
             .map(tagEl => tagEl.textContent.trim());
 
-        let media: I.Media = {
+        const media: I.Media = {
             url: url,
             previewUrl: previewUrl,
             author: username,

--- a/app/plugins/subscribestar.ts
+++ b/app/plugins/subscribestar.ts
@@ -39,8 +39,13 @@ export class SubscribeStarPlugin extends BaseSitePlugin {
         // Use mediaInfo corresponding to the image shown in the gallery when using the carousel viewer
         const downloadLink = querySelector<HTMLAnchorElement>('a.gallery-image_original_link');
         if (downloadLink) {
+            // Handle cases with both relative and absolute URLs
             const downloadUrl = downloadLink.href;
-            mediaInfo = mediaInfos.find(info => info.url === downloadUrl) ?? mediaInfo;
+            const downloadHref = downloadLink.getAttribute('href')
+            mediaInfo = mediaInfos.find(info => info.url === downloadUrl || 
+                info.url === downloadHref || 
+                downloadUrl === new URL(info.url, window.location.href).href
+            ) ?? mediaInfo;
         }
 
         // Title may or may not exist
@@ -84,9 +89,12 @@ export class SubscribeStarPlugin extends BaseSitePlugin {
         const siteFilename = mediaInfo.original_filename;
         const { filename, ext: extension } = getFilenameParts(siteFilename);
         const type = MediaTypeMap[mediaInfo.type];
+        // Ensure absolute URLs
+        const url = new URL(mediaInfo.url, window.location.href).href;
+        const previewUrl = new URL(mediaInfo.url, window.location.href).href;
         return {
-            url: mediaInfo.url,
-            previewUrl: mediaInfo.preview_url,
+            url,
+            previewUrl,
             submissionId: `${mediaInfo.id}`,
             siteFilename,
             filename,

--- a/app/ui/page/page.tsx
+++ b/app/ui/page/page.tsx
@@ -125,6 +125,9 @@ export default class Page extends React.Component<PageProps, PageState> implemen
                         downloadState: download.success ? E.DownloadState.Exists : E.DownloadState.NotDownloaded,
                     }), 2000);
                 })
+                .catch(() => {
+                    this.setState({ downloadState: E.DownloadState.Error });
+                })
         });
     }
 

--- a/app/ui/page/pageOverlay.tsx
+++ b/app/ui/page/pageOverlay.tsx
@@ -37,6 +37,13 @@ DownloadStatusUi[E.DownloadState.Done] = DownloadStatusUi[E.DownloadState.Exists
 DownloadStatusUi[E.DownloadState.Error] = <IconError title="Download error" />
 DownloadStatusUi[E.DownloadState.InProgress] = <IconSpinner title="Downloading" />
 
+const DownloadStatusMessage: { [state: number]: string } = {
+    [E.DownloadState.Done]: 'Downloaded!',
+    [E.DownloadState.Error]: 'Error occured while downloading',
+    [E.DownloadState.InProgress]: 'Downloading...'
+}
+
+
 export default class PageOverlay extends React.Component<PageOverlayProps, PageOverlayState> {
     private _mouseLeaveTimeout: number;
 
@@ -133,6 +140,7 @@ export default class PageOverlay extends React.Component<PageOverlayProps, PageO
         }
 
         const downloadStatusUi = DownloadStatusUi[props.downloadState];
+        const message = DownloadStatusMessage[props.downloadState];
 
         //TODO: fix mini-download button if the downloaded file exists
         return (
@@ -164,12 +172,14 @@ export default class PageOverlay extends React.Component<PageOverlayProps, PageO
                             alternateBalloonUi
                         ) : (
                             <div className={n("bubble")}>
+                                {message && <div className={n('message')}>{message}</div>}
                                 {props.hasMedia && (
                                     <ActionButton
                                         onClick={this.onClickDownload}
                                         title={'Hotkey: D'}
                                         icon={downloadStatusUi || IconDownload}
                                         disabled={props.downloadState === E.DownloadState.InProgress}
+                                        className={props.downloadState === E.DownloadState.Error ? n('error') : undefined}
                                     >
                                         Download
                                     </ActionButton>

--- a/app/utils/dom.ts
+++ b/app/utils/dom.ts
@@ -5,7 +5,7 @@ export function querySelectorAll<T extends HTMLElement>(selector: string, scope?
     return Array.from(list);
 }
 
-export function querySelector<T extends HTMLElement>(selector: string, scope?: HTMLElement): T {
+export function querySelector<T extends HTMLElement>(selector: string, scope?: HTMLElement): T | null {
     return <T>((scope || document).querySelector(selector));
 }
 

--- a/src/overlayUi.css
+++ b/src/overlayUi.css
@@ -31,6 +31,10 @@
     opacity: 1;
 }
 
+#ry-ui .ry-message {
+    margin: 4px;
+}
+
 #ry-ui a {
     text-decoration: none !important;
     border-bottom: none;
@@ -59,12 +63,21 @@
     color: #fff !important;
 }
 
+#ry-ui .ry-action.ry-error {
+    background-color: #600;
+    border-color: #600;
+}
+
 #ry-ui .ry-action.ry-nolabel {
     min-width: 0;
 }
 
 #ry-ui .ry-action:hover {
     background-color: #0081e0;
+}
+
+#ry-ui .ry-action.ry-error:hover {
+    background-color: #900;
 }
 
 #ry-ui .ry-action:disabled,


### PR DESCRIPTION
- Fixes Itaku gallery folder links (#181)
- Fixes SubscribeStar downloading (#182)
- Fixes Patreon audio detection (#180)
- Adds video support to SoFurry plugin 
- Adds better UI for displaying errors when downloading