### PR TITLE
Add download support for Patreon's image viewer

### DIFF
--- a/app/utils/dom.ts
+++ b/app/utils/dom.ts
@@ -61,3 +61,13 @@ export function getPageLinksFromSelector(selector: string, getIdFromSubmissionUr
     const list = getPageLinksFromAnchors(links, getIdFromSubmissionUrl);
     return list;
 }
+
+export function getFirstNonBodyAncestorElement(element: Element) {
+    if (element === document.body) {
+        return undefined;
+    }
+    while (element.parentElement != document.body) {
+        element = element.parentElement;
+    }
+    return element;
+}


### PR DESCRIPTION
This allows Raccoony to download directly from Patreon's image viewer (AKA lightbox) much the same way as with SubscribeStar or Itaku for multi-image posts. Issue referenced in #180 